### PR TITLE
Enable compatibility for tensorflow v2.X

### DIFF
--- a/yolo3/model.py
+++ b/yolo3/model.py
@@ -7,6 +7,11 @@ import logging
 from functools import wraps
 
 import tensorflow as tf
+if tf.__version__[0] == '2':
+    logging.debug("Tensorflow version 2.X detected, enabling compatibility with version 1.X.")
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
+
 from keras import backend as K
 from keras.layers import Conv2D, Add, ZeroPadding2D, UpSampling2D, Concatenate, MaxPooling2D
 from keras.layers import Input, Lambda

--- a/yolo3/yolo.py
+++ b/yolo3/yolo.py
@@ -95,6 +95,11 @@ class YOLO(object):
         if K.backend() == 'tensorflow':
             import tensorflow as tf
             from keras.backend.tensorflow_backend import set_session
+            if tf.__version__[0] == '2':
+                logging.debug("Tensorflow version 2.X detected, enabling compatibility with version 1.X.")
+                import tensorflow.compat.v1 as tf
+                tf.disable_v2_behavior()
+                from tensorflow.python.keras.backend import set_session
 
             config = tf.ConfigProto(allow_soft_placement=True,
                                     log_device_placement=False)
@@ -114,7 +119,10 @@ class YOLO(object):
             sess = tf.Session(config=config)
             set_session(sess)
 
-        self.sess = K.get_session()
+        if tf.__version__[0] == '2':
+            self.sess = tf.keras.backend.get_session()
+        else:
+            self.sess = K.get_session()
 
     def _create_model(self):
         # weights_path = update_path(self.weights_path)


### PR DESCRIPTION
Added explicit backwards compatibility if the active Python environment
is running tensorflow 2.X (the source code is originally written for
tensorflow 1.X, some of whose features aren't identically reflected in
2.X).